### PR TITLE
Fix docker build command

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,7 @@
 To build the images:
 
 ```bash
-docker build -t conda_cuda_base:latest ./base
+docker build -t conda_cuda_base_2019:latest ./base
 docker build -t numba_gtc2019:latest ./notebooks
 ```
 


### PR DESCRIPTION
Make base image name consistent with the Dockerfile for numba_gtc2019